### PR TITLE
Fix deprecation issues. Test with Moodle 3.9 and 3.10

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -78,13 +78,13 @@ class auth_plugin_samlidp extends auth_plugin_base {
     private function set_cookie ($user) {
         if (file_exists($this->simplesamlAutoloadPhp)) {
             require_once($this->simplesamlAutoloadPhp);
-            $sspConfig = SimpleSAML_Configuration::getInstance();
-            $sspAuthsources = SimpleSAML_Configuration::getConfig('authsources.php');
+            $sspConfig = SimpleSAML\Configuration::getInstance();
+            $sspAuthsources = SimpleSAML\Configuration::getConfig('authsources.php');
             $cookieName = $sspAuthsources->getValue($this->config->simplesaml_authsource);
             $uid = $user->id;
-            if ($cookieName && isset($cookieName{'cookie_name'}) && $cookieName{'cookie_name'}) {
+            if ($cookieName && isset($cookieName['cookie_name']) && $cookieName['cookie_name']) {
                 $salt = $sspConfig->getValue('secretsalt');
-                setcookie($cookieName{'cookie_name'}, hash_hmac('sha1', $salt.$uid, $salt).':'.$uid, 0, $sspConfig->getValue('session.cookie.path'));
+                setcookie($cookieName['cookie_name'], hash_hmac('sha1', $salt.$uid, $salt).':'.$uid, 0, $sspConfig->getValue('session.cookie.path'));
             } else {
                 $this->report_misconfigured_authsouces();
             }
@@ -104,9 +104,8 @@ class auth_plugin_samlidp extends auth_plugin_base {
     public function user_authenticated_hook (&$user, $username, $password) {
         global $SESSION, $USER;
 
-        $this->set_cookie($user);
-
         if (isset($SESSION->samlurl) && $SESSION->samlurl) {
+            $this->set_cookie($user);
             $samlurl = $SESSION->samlurl;
             unset($SESSION->samlurl);
             complete_user_login($user);     # need to run it here otherwise the moodle user is not really logged in
@@ -126,12 +125,12 @@ class auth_plugin_samlidp extends auth_plugin_base {
         if (file_exists($this->simplesamlAutoloadPhp)) {
             $returnto = optional_param('ReturnTo', '', PARAM_URL);
             require_once($this->simplesamlAutoloadPhp);
-            $sspConfig = SimpleSAML_Configuration::getInstance();
-            $sspAuthsources = SimpleSAML_Configuration::getConfig('authsources.php');
+            $sspConfig = SimpleSAML\Configuration::getInstance();
+            $sspAuthsources = SimpleSAML\Configuration::getConfig('authsources.php');
             $cookieName = $sspAuthsources->getValue($this->config->simplesaml_authsource);
-            if ($cookieName && isset($cookieName{'cookie_name'}) && $cookieName{'cookie_name'}) {
+            if ($cookieName && isset($cookieName['cookie_name']) && $cookieName['cookie_name']) {
 
-                setcookie($cookieName{'cookie_name'}, '',  time() - 3600, $sspConfig->getValue('session.cookie.path'));
+                setcookie($cookieName['cookie_name'], '',  time() - 3600, $sspConfig->getValue('session.cookie.path'));
 
                 if (ini_get('session.use_cookies')) {
                     $params = session_get_cookie_params();

--- a/moodle/lib/Auth/Source/External.php
+++ b/moodle/lib/Auth/Source/External.php
@@ -36,21 +36,21 @@
  */
 ################################################################################
 
-class sspmod_moodle_Auth_Source_External extends SimpleSAML_Auth_Source {
+class sspmod_moodle_Auth_Source_External extends SimpleSAML\Auth\Source {
     const STATE_IDENT = 'moodle:External';
-    private $config;
+    private $config = array();
 
     public function __construct($info, $config) {
         assert('is_array($info)');
         assert('is_array($config)');
 
         parent::__construct($info, $config);
-        if (!isset($config{'cookie_name'})) {
-            throw new SimpleSAML_Error_Exception('Misconfiguration in authsources');    # in the moodle part in config/authsources.php there must be 'cookie_name' setting
+        if (!isset($config['cookie_name'])) {
+            throw new SimpleSAML\Error\Exception('Misconfiguration in authsources');    # in the moodle part in config/authsources.php there must be 'cookie_name' setting
         }
-        $ssp_config = SimpleSAML_Configuration::getInstance();
-        $config{'cookie_path'} = $ssp_config->getValue('session.cookie.path');
-        $config{'cookie_salt'} = $ssp_config->getValue('secretsalt');
+        $ssp_config = SimpleSAML\Configuration::getInstance();
+        $config['cookie_path'] = $ssp_config->getValue('session.cookie.path');
+        $config['cookie_salt'] = $ssp_config->getValue('secretsalt');
         $this->config = $config;
     }
 
@@ -63,44 +63,44 @@ class sspmod_moodle_Auth_Source_External extends SimpleSAML_Auth_Source {
         } else {
             # redirect to a login page
             $state['moodle:AuthID'] = $this->authId;
-            $state_id = SimpleSAML_Auth_State::saveState($state, self::STATE_IDENT);
-            $return_to = SimpleSAML_Module::getModuleURL('moodle/resume.php', array('State' => $state_id));
-            $auth_page = $this->config{'login_url'} . '?ReturnTo=' . $return_to;
-            SimpleSAML_Utilities::redirect($auth_page, array('ReturnTo' => $return_to));
+            $state_id = SimpleSAML\Auth\State::saveState($state, self::STATE_IDENT);
+            $return_to = SimpleSAML\Module::getModuleURL('moodle/resume.php', array('State' => $state_id));
+            $auth_page = $this->config['login_url'] . '?ReturnTo=' . $return_to;
+            SimpleSAML\Utilities::redirect($auth_page, array('ReturnTo' => $return_to));
         }
     }
 
     public static function resume() {
         if (!isset($_REQUEST['State'])) {
-            throw new SimpleSAML_Error_BadRequest('Missing "State" parameter.');
+            throw new SimpleSAML\Error\BadRequest('Missing "State" parameter.');
         }
         $state_id = (string)$_REQUEST['State'];
 
-        $state = SimpleSAML_Auth_State::loadState($state_id, self::STATE_IDENT);
-        $source = SimpleSAML_Auth_Source::getById($state['moodle:AuthID']);
+        $state = SimpleSAML\Auth\State::loadState($state_id, self::STATE_IDENT);
+        $source = SimpleSAML\Auth\Source::getById($state['moodle:AuthID']);
         if ($source === NULL) {
-            throw new SimpleSAML_Error_Exception('Could not find authentication source with id ' . $state[self::AUTHID]);
+            throw new SimpleSAML\Error\Exception('Could not find authentication source with id ' . $state[self::AUTHID]);
         }
 
         if (! ($source instanceof self)) {
-            throw new SimpleSAML_Error_Exception('Authentication source type changed.');
+            throw new SimpleSAML\Error\Exception('Authentication source type changed.');
         }
 
         $user = $source->getUser($state);
         if ($user === NULL) {
-            throw new SimpleSAML_Error_Exception('User not authenticated after login page.');
+            throw new SimpleSAML\Error\Exception('User not authenticated after login page.');
         }
         $state['Attributes'] = $user;
 
-        SimpleSAML_Auth_Source::completeAuth($state);
+        SimpleSAML\Auth\Source::completeAuth($state);
         exit(); # should never reach here
     }
 
     private function getUser() {
         $uid = 0;
-        if (isset($_COOKIE{$this->config{'cookie_name'}}) && $_COOKIE{$this->config{'cookie_name'}}) {
-            $str_cookie = $_COOKIE{$this->config{'cookie_name'}};
-            # cookie created by: "setcookie($cookieName{'cookie_name'}, hash_hmac('sha1', $salt.$account->uid, $salt).':'.$uid, 0, $sspConfig->getValue('session.cookie.path'));"
+        if (isset($_COOKIE[$this->config['cookie_name']]) && $_COOKIE[$this->config['cookie_name']]) {
+            $str_cookie = $_COOKIE[$this->config['cookie_name']];
+            # cookie created by: "setcookie($cookieName['cookie_name'], hash_hmac('sha1', $salt.$account->uid, $salt).':'.$uid, 0, $sspConfig->getValue('session.cookie.path'));"
             # in auth/samlidp/auth.php in Moodle
             $arr_cookie = explode(':', $str_cookie);
 
@@ -108,17 +108,17 @@ class sspmod_moodle_Auth_Source_External extends SimpleSAML_Auth_Source {
                 && (isset($arr_cookie[1]) && $arr_cookie[1])
             ) {
                 # make sure no one manipulated the hash or the uid in the cookie before we trust the uid
-                if (hash_hmac('sha1', $this->config{'cookie_salt'}.$arr_cookie[1], $this->config{'cookie_salt'}) == $arr_cookie[0]) {
+                if (hash_hmac('sha1', $this->config['cookie_salt'].$arr_cookie[1], $this->config['cookie_salt']) == $arr_cookie[0]) {
                     $uid = (int)$arr_cookie[1];
                 } else {
-                    throw new SimpleSAML_Error_Exception('Cookie hash invalid.');
+                    throw new SimpleSAML\Error\Exception('Cookie hash invalid.');
                 }
             }
         }
 
         # our cookie must be removed here
-        if (isset($_COOKIE{$this->config{'cookie_name'}})) {
-            setcookie($this->config{'cookie_name'}, "", time() - 3600, $this->config{'cookie_path'});
+        if (isset($_COOKIE[$this->config['cookie_name']])) {
+            setcookie($this->config['cookie_name'], "", time() - 3600, $this->config['cookie_path']);
         }
 
         if ($uid) {
@@ -126,18 +126,18 @@ class sspmod_moodle_Auth_Source_External extends SimpleSAML_Auth_Source {
             global $CFG, $DB;
             define('CLI_SCRIPT', true);
             define('WEB_CRON_EMULATED_CLI', 'defined');
-            $configphp = $this->config{'moodle_coderoot'}."/config.php";
-            $userlib = $this->config{'moodle_coderoot'}."/user/profile/lib.php";
+            $configphp = $this->config['moodle_coderoot']."/config.php";
+            $userlib = $this->config['moodle_coderoot']."/user/profile/lib.php";
             if (file_exists($configphp)) {
                 require_once($configphp);
             } else {
-                throw new SimpleSAML_Error_Exception('Moodle app instantiation failure: cannot require()' . $configphp);
+                throw new SimpleSAML\Error\Exception('Moodle app instantiation failure: cannot require()' . $configphp);
             }
 
             if (file_exists($userlib)) {
                 require_once($userlib);
             } else {
-                throw new SimpleSAML_Error_Exception('Moodle app instantiation failure: cannot require()' . $userlib);
+                throw new SimpleSAML\Error\Exception('Moodle app instantiation failure: cannot require()' . $userlib);
             }
 
             # query for a user
@@ -152,10 +152,10 @@ class sspmod_moodle_Auth_Source_External extends SimpleSAML_Auth_Source {
                 unset($user->secret);
                 $user->uid = $user->id;     # i dont believe this is strictly necessary. just nice-to-have
                 foreach ((array)$user as $param => $value) {
-                    $userattr{$param} = array($value);
+                    $userattr[$param] = array($value);
                 }
                 foreach ($profile_fields as $param => $value) {
-                    $userattr{'profile_field_'.$param} = array($value);
+                    $userattr['profile_field_'.$param] = array($value);
                 }
             }
             return $userattr;
@@ -170,17 +170,17 @@ class sspmod_moodle_Auth_Source_External extends SimpleSAML_Auth_Source {
             session_start();
         }
 
-        if (isset($_COOKIE{$this->config{'cookie_name'}})) {
-            setcookie($this->config{'cookie_name'}, "", time() - 3600, $this->config{'cookie_path'});
+        if (isset($_COOKIE[$this->config['cookie_name']])) {
+            setcookie($this->config['cookie_name'], "", time() - 3600, $this->config['cookie_path']);
         }
         session_destroy();
 
-        $logout_url = $this->config{'logout_url'};
+        $logout_url = $this->config['logout_url'];
         if (!empty($state['ReturnTo'])) {
             $logout_url .= '?ReturnTo=' . $state['ReturnTo'];
         }
 
-        SimpleSAML_Utilities::redirect($logout_url);
+        SimpleSAML\Utilities::redirect($logout_url);
         die();
     }
 }

--- a/version.php
+++ b/version.php
@@ -24,6 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2018061303;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2018061304;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2016051900;        // Requires this Moodle version.
 $plugin->component = 'auth_samlidp';    // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
Deprecation issues related to both php7.4 warnings and SimpleSAMLphp usage of namespaces are fixed. Compatibility with older php should not be broken
In auth.php in user_authenticated_hook() cookie creation is moved inside if() so now the SAML cookie is created only upon a SAML auth request
The plugin tested on both Moodle 3.9 and Moodle 3.10 versions, using the newest SimpleSAMLphp 1.19.0